### PR TITLE
html 빌드 자동화 설정. readme.md 파일 업데이트

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,3 +124,7 @@ end
 
 # A gem necessary for ActiveRecord tests with IBM DB
 gem 'ibm_db' if ENV['IBM_DB']
+
+
+# added by RORLAB
+gem 'guard-shell'

--- a/README.md
+++ b/README.md
@@ -1,23 +1,126 @@
 ## 레일스 가이드 한글 번역
 
-가이드 번역 관련된 사항은 `guides-ko` 브랜치에서만 작업합니다. `master` 브랜치는 `rails/rails` 와의 동기화를 위한것으로 이곳에 직접 커밋하거나 풀리퀘스트 하지 않습니다.
+가이드 번역은 `guides-ko` 브랜치에서만 작업합니다. 편의를 위해 이 저장소의 디폴트 브랜치를 `guides-ko`로 지정해 놓았습니다. 
 
-## 번역 파일 생성 하기
+> **주의** : `master` 브랜치는 `rails/rails` 와의 동기화를 위한것으로 이곳에 직접 커밋하거나 풀리퀘스트 하지 않습니다.
 
-```
-$ cd guides
-$ bundle exec rake guides:generate:html:ko ALL=1
-```
+## 준비 작업
 
-`ALL=1` 옵션을 붙이지 않으면 변경된 파일만 생성
+1. 현재 저장소를 `fork`한다.
+2. 방금 `fork`한 본인 계정의 저장소 **SSH clone URL**을 복사한다.
+3. 터미널을 열고 원하는 디렉토리 상에서 아래와 같이 `git clone` 명령을 실행한 후 `rails-guides` 디렉토리로 이동한다.
 
-### 배포하기
+  ```bash
+  $ git clone https://github.com/{user_account}/rails-guides.git
+  $ cd rails-guides
+  ```
 
-```
-$ bundle exec rake guides:generate:html:ko:publish ALL=1
-```
+4. Gemfile이 존재하는지 확인한 후 번들 설치한다.
 
-## 번역 기여하기
+  ```bash
+  $ bundle install
+  ```
+  
+5.  `guides` 디렉토리로 이동한 후 `rake` 태스크 목록을 확인한다. 
+
+  ```bash
+  $ cd guides
+  $ rake -T
+  rake guides:generate                  # Generate guides (for authors), use ONLY=foo to process just "foo.md"
+  rake guides:generate:html             # Generate HTML guides
+  rake guides:generate:html:ko          # Generate HTML guides from source/ko (for RORLAB)
+  rake guides:generate:html:ko:publish  # Publish the guides to shared/rg (for ROR Lab.)
+  rake guides:generate:kindle           # Generate .mobi file
+  rake guides:generate:kindle:ko        # Generate .mobi file
+  rake guides:help                      # Show help
+  rake guides:validate                  # Validate guides, use ONLY=foo to process just "foo.html"
+  ```
+
+## 번역 작업
+
+1. 이제 번역할 마크다운 파일이 있는 디렉토리로 이동한다. 
+
+  ```bash
+  $ cd sources/ko
+  ```
+
+2. 본인이 번역하기를 원하는 파일이나 수정이 필요한 파일을 찾아 에디터로 열고 작업을 한다. 
+3. 번역 작업 중간 중간에 html 파일로 확인하여 작성한 번역이 제대로 포맷되었는지 확인한다. 이 과정은 반드시 필요하다. 아래와 같이 명령을 실행하면 `rails-guides/guides/output/ko` 디렉토리로 `html` 파일이 생성/업데이트되는데, 본인이 작업한 파일명의 `.html` 확장자를 가진 파일을 브라우져로 열어 본다. 
+
+  ```bash
+  $ cd rails-guides/guides
+  $ bundle exec rake guides:generate:html:ko [ALL=1]
+  $ cd rails-guides/guides/output/ko
+  $ open xxxx.html
+  ```
+
+
+  > **노트** : `ALL=1` 옵션을 붙이지 않으면 변경된 파일만 생성
+
+
+4. 작업이 완료되면 적절한 메시지와 함께 커밋한다.
+
+  ```bash
+  $ cd rails-guides
+  $ git add .
+  $ git commit -m "xxxxxxxxxx.md 번역 시작함."
+  $ git push origin rails-guides
+  ```
+ 
+5. 이제 브라우저 상에서 github 본인계정 상의 rails-guides 저장소로 이동한 후 `pull request"을 작성한다. 
+
+
+## 번역 작업시 자동으로 html 파일 빌드하기
+
+파일 수정시마다 커맨드라인에서 html 파일을 빌드하는 것은 매우 번거롭습니다. `guard-shell` 젬을 이용하면 파일 변경시마다 자동으로 빌드과정을 수행할 수 있습니다. 
+
+1. `rails-guides` 디렉토리의 `Gemfile`을 열고 하단에 `guard-shell` 젬을 추가한다. 
+  
+  ```bash
+  $ cd rails-guides
+  $ vi Gemfile
+  gem 'guard-shell'
+  ```
+2. 이어서 번들 설치한다.
+
+  ```bash
+  $ bundle install
+  ```
+  
+3. `Guardfile`을 생성하기 위해 아래와 같이 명령을 실행한다. 
+
+  ```bash
+  $ cd guides
+  $ guard init shell
+  ```
+ 
+4.  생성된 `Guardfile`을 에디터로 열고 아래와 같이 추가해 준다. 
+
+  ```ruby
+   guard :shell do
+      watch(/(.*).md/) { system("rake guides:generate:html:ko")}
+  end
+  ```
+  
+5. `rails-guides/guides` 디렉토리에서 아래와 같이 실행한다.
+
+  ```bash
+  $ cd rails-guides/guides
+  $ bundle exec guard
+  ```
+  
+6. 이제 번역 작업 중인 마크다운 파일을 변경하게 되면 자동으로 html 빌드를 위한 `rake` 태스크가 자동으로 실행된다. 
+
+  ```bash
+  $ bundle exec guard
+  10:12:50 - INFO - Guard is now watching at '/Users/{user-account}/.../rails-guides/guides'
+  /Users/{user-account}/.rbenv/versions/2.2.0/bin/ruby rails_guides.rb
+  Generating 4_2_release_notes.md as 4_2_release_notes.html
+  [1] guard(main)>_
+  ```
+
+
+## 기여하기
 
 누구라도 번역에 참가 할 수 있습니다. guides/source/ko 하위의 파일들을 번역후 `guides-ko` 브랜치에 풀리퀘스트 하면됩니다.
 

--- a/guides/Guardfile
+++ b/guides/Guardfile
@@ -1,0 +1,31 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec feature)
+
+## Uncomment to clear the screen before every task
+# clearing :on
+
+## Guard internally checks for changes in the Guardfile and exits.
+## If you want Guard to automatically start up again, run guard in a
+## shell loop, e.g.:
+##
+##  $ while bundle exec guard; do echo "Restarting Guard..."; done
+##
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), the you will want to move the Guardfile
+## to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Add files and commands to this file, like the example:
+#   watch(%r{file/path}) { `command(s)` }
+#
+guard :shell do
+  watch(/(.*).md/) { system("rake guides:generate:html:ko")}
+end

--- a/guides/source/ko/4_2_release_notes.md
+++ b/guides/source/ko/4_2_release_notes.md
@@ -7,7 +7,7 @@
 
 * 액티브 잡 [[[Active Job]]]
 
-* 비동기적 이메일 [[[Asynchronous mails]]]
+* 비동기 메일 [[[Asynchronous mails]]]
 
 * 애디키트 레코드 [[[Adequate Record]]]
 
@@ -15,19 +15,14 @@
 
 * 외래키 지원 [[[Foreign key support]]]
 
-이번 릴리스 노트에서는 주요 변경내용만 설명한다. 다른 기능, 오류 수정, 그리고 기타 다른 변경내용을 알고자 한다면 깃헙 레일스 저장소에 있는 [커밋 목록](https://github.com/rails/rails/commits/4-2-stable)이나 변경로그를 참고하기 바란다. [[[These release notes cover only the major changes. To learn about other features, bug fixes, and changes, please refer to the changelogs or check out the [list of commits](https://github.com/rails/rails/commits/4-2-stable) in the main Rails repository on GitHub.]]]
+이번 릴리스 노트에서는 주요 변경내용만을 설명한다. 다른 기능이나 , 오류 수정, 그리고 기타 다른 변경내용을 알고자 한다면 깃헙 레일스 저장소에 있는 변경로그나 [커밋 목록](https://github.com/rails/rails/commits/4-2-stable)을 참고하기 바란다. [[[These release notes cover only the major changes. To learn about other features, bug fixes, and changes, please refer to the changelogs or check out the [list of commits](https://github.com/rails/rails/commits/4-2-stable) in the main Rails repository on GitHub.]]]
 
 --------------------------------------------------------------------------------
 
 [Upgrading to Rails 4.2] 레일스 4.2로 업그레이드하기
 ----------------------
 
-If you're upgrading an existing application, it's a great idea to have good test
-coverage before going in. You should also first upgrade to Rails 4.1 in case you
-haven't and make sure your application still runs as expected before attempting
-to upgrade to Rails 4.2. A list of things to watch out for when upgrading is
-available in the guide [Upgrading Ruby on
-Rails](upgrading_ruby_on_rails.html#upgrading-from-rails-4-1-to-rails-4-2).
+기존 애플리케이션을 업그레이드할 때는 먼저 테스트 커버리지를 높이는 것이 좋다. 먼저 레일스 4.1로 업그레이드한 후 애플리케이션 실행시에 문제가 없다는 것을 확인한 후 레일스 4.2로 업그레이드해야 한다. [[[If you're upgrading an existing application, it's a great idea to have good test coverage before going in. You should also first upgrade to Rails 4.1 in case you haven't and make sure your application still runs as expected before attempting to upgrade to Rails 4.2. A list of things to watch out for when upgrading is available in the guide [Upgrading Ruby on Rails](upgrading_ruby_on_rails.html#upgrading-from-rails-4-1-to-rails-4-2).]]]
 
 
 [Major Features] 주요 기능
@@ -35,20 +30,12 @@ Rails](upgrading_ruby_on_rails.html#upgrading-from-rails-4-1-to-rails-4-2).
 
 ### [Active Job] 액티브 잡
 
-Active Job is a new framework in Rails 4.2. It is a common interface on top of
-queuing systems like [Resque](https://github.com/resque/resque), [Delayed
-Job](https://github.com/collectiveidea/delayed_job),
-[Sidekiq](https://github.com/mperham/sidekiq), and more.
+액티브 잡은 레일스 4.2에서 새로 도입한 프레임워크이며 [Resque](https://github.com/resque/resque), [Delayed Job](https://github.com/collectiveidea/delayed_job), [Sidekiq](https://github.com/mperham/sidekiq) 등과 같은 큐 등록 시스템 기반 위에 인터페이스를 일반화한 것이다. [[[Active Job is a new framework in Rails 4.2. It is a common interface on top of queuing systems like [Resque](https://github.com/resque/resque), [Delayed Job](https://github.com/collectiveidea/delayed_job), [Sidekiq](https://github.com/mperham/sidekiq), and more.]]]
 
-Jobs written with the Active Job API run on any of the supported queues thanks
-to their respective adapters. Active Job comes pre-configured with an inline
-runner that executes jobs right away.
+액티브 잡 API로 작성한 잡은 각각에 대한 내장 어댑터 덕분에 어떤 지원 큐에서도 실행된다. 액티브 잡은 잡을 즉시 실행하는 인라인 러너로 미리 설정되어 있다. [[[Jobs written with the Active Job API run on any of the supported queues thanks to their respective adapters. Active Job comes pre-configured with an inline runner that executes jobs right away.]]]
 
-Jobs often need to take Active Record objects as arguments. Active Job passes
-object references as URIs (uniform resource identifiers) instead of marshaling
-the object itself. The new [Global ID](https://github.com/rails/globalid)
-library builds URIs and looks up the objects they reference. Passing Active
-Record objects as job arguments just works by using Global ID internally.
+
+Jobs often need to take Active Record objects as arguments. Active Job passes object references as URIs (uniform resource identifiers) instead of marshaling the object itself. The new [Global ID](https://github.com/rails/globalid) library builds URIs and looks up the objects they reference. Passing Active Record objects as job arguments just works by using Global ID internally.
 
 For example, if `trashable` is an Active Record object, then this job runs
 just fine with no serialization involved:


### PR DESCRIPTION
## 레일스 가이드 한글 번역

가이드 번역은 `guides-ko` 브랜치에서만 작업합니다. 편의를 위해 이 저장소의 디폴트 브랜치를 `guides-ko`로 지정해 놓았습니다. 

> **주의** : `master` 브랜치는 `rails/rails` 와의 동기화를 위한것으로 이곳에 직접 커밋하거나 풀리퀘스트 하지 않습니다.
## 준비 작업
1. 현재 저장소를 `fork`한다.
2. 방금 `fork`한 본인 계정의 저장소 **SSH clone URL**을 복사한다.
3. 터미널을 열고 원하는 디렉토리 상에서 아래와 같이 `git clone` 명령을 실행한 후 `rails-guides` 디렉토리로 이동한다.
   
   ``` bash
   $ git clone https://github.com/{user_account}/rails-guides.git
   $ cd rails-guides
   ```
4. Gemfile이 존재하는지 확인한 후 번들 설치한다.
   
   ``` bash
   $ bundle install
   ```
5.  `guides` 디렉토리로 이동한 후 `rake` 태스크 목록을 확인한다. 
   
   ``` bash
   $ cd guides
   $ rake -T
   rake guides:generate                  # Generate guides (for authors), use ONLY=foo to process just "foo.md"
   rake guides:generate:html             # Generate HTML guides
   rake guides:generate:html:ko          # Generate HTML guides from source/ko (for RORLAB)
   rake guides:generate:html:ko:publish  # Publish the guides to shared/rg (for ROR Lab.)
   rake guides:generate:kindle           # Generate .mobi file
   rake guides:generate:kindle:ko        # Generate .mobi file
   rake guides:help                      # Show help
   rake guides:validate                  # Validate guides, use ONLY=foo to process just "foo.html"
   ```
## 번역 작업
1. 이제 번역할 마크다운 파일이 있는 디렉토리로 이동한다. 
   
   ``` bash
   $ cd sources/ko
   ```
2. 본인이 번역하기를 원하는 파일이나 수정이 필요한 파일을 찾아 에디터로 열고 작업을 한다. 
3. 번역 작업 중간 중간에 html 파일로 확인하여 작성한 번역이 제대로 포맷되었는지 확인한다. 이 과정은 반드시 필요하다. 아래와 같이 명령을 실행하면 `rails-guides/guides/output/ko` 디렉토리로 `html` 파일이 생성/업데이트되는데, 본인이 작업한 파일명의 `.html` 확장자를 가진 파일을 브라우져로 열어 본다. 
   
   ``` bash
   $ cd rails-guides/guides
   $ bundle exec rake guides:generate:html:ko [ALL=1]
   $ cd rails-guides/guides/output/ko
   $ open xxxx.html
   ```
   
   > **노트** : `ALL=1` 옵션을 붙이지 않으면 변경된 파일만 생성
4. 작업이 완료되면 적절한 메시지와 함께 커밋한다.
   
   ``` bash
   $ cd rails-guides
   $ git add .
   $ git commit -m "xxxxxxxxxx.md 번역 시작함."
   $ git push origin rails-guides
   ```
5. 이제 브라우저 상에서 github 본인계정 상의 rails-guides 저장소로 이동한 후 `pull request"을 작성한다. 
## 번역 작업시 자동으로 html 파일 빌드하기

파일 수정시마다 커맨드라인에서 html 파일을 빌드하는 것은 매우 번거롭습니다. `guard-shell` 젬을 이용하면 파일 변경시마다 자동으로 빌드과정을 수행할 수 있습니다. 
1. `rails-guides` 디렉토리의 `Gemfile`을 열고 하단에 `guard-shell` 젬을 추가한다. 
   
   ``` bash
   $ cd rails-guides
   $ vi Gemfile
   gem 'guard-shell'
   ```
2. 이어서 번들 설치한다.
   
   ``` bash
   $ bundle install
   ```
3. `Guardfile`을 생성하기 위해 아래와 같이 명령을 실행한다. 
   
   ``` bash
   $ cd guides
   $ guard init shell
   ```
4.  생성된 `Guardfile`을 에디터로 열고 아래와 같이 추가해 준다. 
   
   ``` ruby
   guard :shell do
     watch(/(.*).md/) { system("rake guides:generate:html:ko")}
   end
   ```
5. `rails-guides/guides` 디렉토리에서 아래와 같이 실행한다.
   
   ``` bash
   $ cd rails-guides/guides
   $ bundle exec guard
   ```
6. 이제 번역 작업 중인 마크다운 파일을 변경하게 되면 자동으로 html 빌드를 위한 `rake` 태스크가 자동으로 실행된다. 
   
   ``` bash
   $ bundle exec guard
   10:12:50 - INFO - Guard is now watching at '/Users/{user-account}/.../rails-guides/guides'
   /Users/{user-account}/.rbenv/versions/2.2.0/bin/ruby rails_guides.rb
   Generating 4_2_release_notes.md as 4_2_release_notes.html
   [1] guard(main)>_
   ```
## 기여하기

누구라도 번역에 참가 할 수 있습니다. guides/source/ko 하위의 파일들을 번역후 `guides-ko` 브랜치에 풀리퀘스트 하면됩니다.
## 빌드 상태

[![Build Status](https://travis-ci.org/rorlakr/rails-guides.svg?branch=guides-ko)](https://travis-ci.org/rorlakr/rails-guides)
## License

Ruby on Rails is released under the [MIT License](http://www.opensource.org/licenses/MIT).
